### PR TITLE
Add legacy compatibility stubs

### DIFF
--- a/MonoChrome/Assets/Scripts/Core/CoreGameManager.cs
+++ b/MonoChrome/Assets/Scripts/Core/CoreGameManager.cs
@@ -1,0 +1,90 @@
+using UnityEngine;
+
+namespace MonoChrome.Core
+{
+    /// <summary>
+    /// Lightweight bridge for legacy references.
+    /// Forwards calls to <see cref="MasterGameManager"/> and <see cref="GameStateMachine"/>.
+    /// </summary>
+    public class CoreGameManager : MonoBehaviour
+    {
+        private static CoreGameManager _instance;
+        public static CoreGameManager Instance
+        {
+            get
+            {
+                if (_instance == null)
+                {
+                    _instance = FindFirstObjectByType<CoreGameManager>();
+                    if (_instance == null)
+                    {
+                        var go = new GameObject("CoreGameManager");
+                        _instance = go.AddComponent<CoreGameManager>();
+                        DontDestroyOnLoad(go);
+                    }
+                }
+                return _instance;
+            }
+        }
+
+        private void Awake()
+        {
+            if (_instance != null && _instance != this)
+            {
+                Destroy(gameObject);
+                return;
+            }
+            _instance = this;
+            DontDestroyOnLoad(gameObject);
+        }
+
+        // Legacy GameState for compatibility
+        public enum GameState
+        {
+            MainMenu,
+            CharacterSelection,
+            Dungeon,
+            Combat,
+            Event,
+            Shop,
+            Rest,
+            GameOver,
+            Victory,
+            Paused
+        }
+
+        public void ChangeState(GameState state)
+        {
+            var target = state switch
+            {
+                GameState.MainMenu => GameStateMachine.GameState.MainMenu,
+                GameState.CharacterSelection => GameStateMachine.GameState.CharacterSelection,
+                GameState.Dungeon => GameStateMachine.GameState.Dungeon,
+                GameState.Combat => GameStateMachine.GameState.Combat,
+                GameState.Event => GameStateMachine.GameState.Event,
+                GameState.Shop => GameStateMachine.GameState.Shop,
+                GameState.Rest => GameStateMachine.GameState.Rest,
+                GameState.GameOver => GameStateMachine.GameState.GameOver,
+                GameState.Victory => GameStateMachine.GameState.Victory,
+                GameState.Paused => GameStateMachine.GameState.Paused,
+                _ => GameStateMachine.GameState.MainMenu
+            };
+            GameStateMachine.Instance?.TryChangeState(target);
+        }
+
+        public void StartNewGame()
+        {
+            MasterGameManager.Instance?.StartNewGame();
+        }
+
+        public void EnterDungeon()
+        {
+            MasterGameManager.Instance?.EnterDungeon();
+        }
+
+        public void StartCombat(string enemyType = "약탈자1", CharacterType characterType = CharacterType.Normal)
+        {
+            MasterGameManager.Instance?.StartCombat(enemyType, characterType);
+        }
+    }
+}

--- a/MonoChrome/Assets/Scripts/Core/LegacySystemBridge.cs
+++ b/MonoChrome/Assets/Scripts/Core/LegacySystemBridge.cs
@@ -17,6 +17,7 @@ namespace MonoChrome.Compatibility
 
         // 기존 시스템 참조 (호환성용)
         private GameManager _legacyGameManager;
+        private DungeonManager _legacyDungeonManager;
 
         // 새 시스템 참조
         private GameStateMachine _newStateMachine;

--- a/MonoChrome/Assets/Scripts/Systems/Combat/CombatManager.cs
+++ b/MonoChrome/Assets/Scripts/Systems/Combat/CombatManager.cs
@@ -1,0 +1,23 @@
+using UnityEngine;
+using MonoChrome.Events;
+using MonoChrome.Core;
+
+namespace MonoChrome.Systems.Combat
+{
+    /// <summary>
+    /// Minimal legacy bridge for old CombatManager references.
+    /// </summary>
+    public class CombatManager : MonoBehaviour
+    {
+        public static CombatManager Instance => FindFirstObjectByType<CombatManager>();
+
+        /// <summary>
+        /// Legacy initialization entry point. Current system triggers combat via events.
+        /// </summary>
+        public void InitializeCombat()
+        {
+            // Actual combat is handled by CombatSystem through CombatEvents.
+            // This method is kept for backward compatibility.
+        }
+    }
+}

--- a/MonoChrome/Assets/Scripts/Systems/Dungeon/DungeonManager.cs
+++ b/MonoChrome/Assets/Scripts/Systems/Dungeon/DungeonManager.cs
@@ -1,0 +1,24 @@
+using UnityEngine;
+
+namespace MonoChrome.Systems.Dungeon
+{
+    /// <summary>
+    /// Minimal legacy bridge for old DungeonManager references.
+    /// </summary>
+    public class DungeonManager : MonoBehaviour
+    {
+        public static DungeonManager Instance => FindFirstObjectByType<DungeonManager>();
+
+        public void GenerateNewDungeon(int stageIndex)
+        {
+            var controller = FindFirstObjectByType<DungeonController>();
+            controller?.GenerateNewDungeon(stageIndex);
+        }
+
+        public void MoveToNode(int nodeIndex)
+        {
+            var controller = FindFirstObjectByType<DungeonController>();
+            controller?.MoveToNode(nodeIndex);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- provide a lightweight `CoreGameManager` bridge
- add placeholder `CombatManager` and `DungeonManager`
- wire `LegacySystemBridge` to reference `_legacyDungeonManager`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6842f5bab4c08328a01f348b713fa206