### PR TITLE
Fix compile references

### DIFF
--- a/MonoChrome/Assets/Scripts/Core/CoreGameManager.cs
+++ b/MonoChrome/Assets/Scripts/Core/CoreGameManager.cs
@@ -86,5 +86,10 @@ namespace MonoChrome.Core
         {
             MasterGameManager.Instance?.StartCombat(enemyType, characterType);
         }
+
+        /// <summary>
+        /// Indicates whether the underlying <see cref="MasterGameManager"/> has finished initialization.
+        /// </summary>
+        public bool IsInitialized => MasterGameManager.Instance?.IsInitialized ?? false;
     }
 }

--- a/MonoChrome/Assets/Scripts/Core/LegacyGameManager.cs
+++ b/MonoChrome/Assets/Scripts/Core/LegacyGameManager.cs
@@ -137,7 +137,15 @@ namespace MonoChrome
                     return GameStateMachine.GameState.MainMenu;
             }
         }
-        
+
+        /// <summary>
+        /// Legacy entry point for starting the game by entering the first dungeon.
+        /// </summary>
+        public void EnterDungeon()
+        {
+            _masterGameManager?.EnterDungeon();
+        }
+
         public bool IsInitialized => _masterGameManager?.IsInitialized ?? false;
     }
 }

--- a/MonoChrome/Assets/Scripts/Core/SystemMigrator.cs
+++ b/MonoChrome/Assets/Scripts/Core/SystemMigrator.cs
@@ -1,4 +1,6 @@
 using UnityEngine;
+using MonoChrome.Systems.Dungeon;
+using MonoChrome.Systems.Combat;
 
 namespace MonoChrome.Core
 {

--- a/MonoChrome/Assets/Scripts/Systems/UI/DirectGameStarter.cs
+++ b/MonoChrome/Assets/Scripts/Systems/UI/DirectGameStarter.cs
@@ -2,6 +2,7 @@ using UnityEngine;
 using UnityEngine.UI;
 using System.Collections;
 using System.Reflection;
+using MonoChrome.Systems.Dungeon;
 
 namespace MonoChrome.Systems.UI
 {


### PR DESCRIPTION
## Summary
- add missing using directives for dungeon/ combat managers
- expose initialization status in CoreGameManager
- provide EnterDungeon legacy bridge

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68430b6e0cc883289a90e8d3cf0ce790