### PR TITLE
Deprecate redundant game managers

### DIFF
--- a/MonoChrome/Assets/Scripts/Core/CoreGameManager.cs
+++ b/MonoChrome/Assets/Scripts/Core/CoreGameManager.cs
@@ -3,9 +3,10 @@ using UnityEngine;
 namespace MonoChrome.Core
 {
     /// <summary>
-    /// Lightweight bridge for legacy references.
+    /// Deprecated lightweight bridge for legacy references.
     /// Forwards calls to <see cref="MasterGameManager"/> and <see cref="GameStateMachine"/>.
     /// </summary>
+    [System.Obsolete("CoreGameManager has been deprecated. Use MasterGameManager.Instance instead.")]
     public class CoreGameManager : MonoBehaviour
     {
         private static CoreGameManager _instance;

--- a/MonoChrome/Assets/Scripts/Core/CoreMainMenuController.cs
+++ b/MonoChrome/Assets/Scripts/Core/CoreMainMenuController.cs
@@ -235,14 +235,14 @@ namespace MonoChrome.Core
             if (_startButton != null)
                 _startButton.interactable = false;
             
-            // CoreGameManager를 통한 게임 시작
-            if (CoreGameManager.Instance != null)
+            // MasterGameManager를 통한 게임 시작
+            if (MasterGameManager.Instance != null)
             {
-                CoreGameManager.Instance.StartNewGame();
+                MasterGameManager.Instance.StartNewGame();
             }
             else
             {
-                Debug.LogWarning("CoreMainMenuController: CoreGameManager not found, loading scene directly");
+                Debug.LogWarning("CoreMainMenuController: MasterGameManager not found, loading scene directly");
                 SceneManager.LoadScene("GameScene");
             }
         }
@@ -322,7 +322,7 @@ MONOCHROME: the Eclipse
             // 디버그 정보 표시
             GUI.Box(new Rect(10, 10, 250, 100), "Main Menu Debug");
             GUI.Label(new Rect(15, 30, 240, 20), $"Initialized: {_isInitialized}");
-            GUI.Label(new Rect(15, 50, 240, 20), $"CoreGameManager: {(CoreGameManager.Instance != null ? "✓" : "✗")}");
+            GUI.Label(new Rect(15, 50, 240, 20), $"MasterGameManager: {(MasterGameManager.Instance != null ? "✓" : "✗")}");
             GUI.Label(new Rect(15, 70, 240, 20), "Space: Start Game, Esc: Quit");
             GUI.Label(new Rect(15, 90, 240, 20), "F1: Direct to GameScene");
         }

--- a/MonoChrome/Assets/Scripts/Core/InitializeReferences.cs
+++ b/MonoChrome/Assets/Scripts/Core/InitializeReferences.cs
@@ -25,7 +25,7 @@ namespace MonoChrome
         
         private void Start()
         {
-            // GameManager와 다른 매니저들이 먼저 초기화되도록 대기
+            // MasterGameManager와 다른 매니저들이 먼저 초기화되도록 대기
             StartCoroutine(InitializeWithDelay());
         }
         
@@ -436,7 +436,7 @@ namespace MonoChrome
             }
             
             // 기타 매니저 참조
-            GameManager gameManager = GameManager.Instance; // 싱글톤 생성 보장
+            MasterGameManager gameManager = MasterGameManager.Instance; // 싱글톤 생성 보장
             CharacterManager characterManager = CharacterManager.Instance; // 싱글톤 생성 보장
             AIManager aiManager = AIManager.Instance; // 싱글톤 생성 보장
             

--- a/MonoChrome/Assets/Scripts/Core/LegacyGameManager.cs
+++ b/MonoChrome/Assets/Scripts/Core/LegacyGameManager.cs
@@ -4,9 +4,10 @@ using MonoChrome.Core;
 namespace MonoChrome
 {
     /// <summary>
-    /// 레거시 GameManager 호환성 클래스
-    /// 기존 코드와의 호환성을 위해 GameManager 패턴을 MasterGameManager로 포워딩
+    /// Deprecated legacy GameManager bridge.
+    /// 포워딩 로직을 통해 <see cref="MasterGameManager"/>와 <see cref="GameStateMachine"/>에 연결합니다.
     /// </summary>
+    [System.Obsolete("GameManager is deprecated. Use MasterGameManager.Instance instead.")]
     public class GameManager : MonoBehaviour
     {
         private static GameManager _instance;

--- a/MonoChrome/Assets/Scripts/Core/QuickUIBuilder.cs
+++ b/MonoChrome/Assets/Scripts/Core/QuickUIBuilder.cs
@@ -415,14 +415,14 @@ namespace MonoChrome.Core
             
             // 캐릭터 선택 버튼
             CreateDebugButton(debugPanel.transform, "Character", new Vector2(0.5f, 0.5f), () => {
-                if (CoreGameManager.Instance != null)
-                    CoreGameManager.Instance.ChangeState(CoreGameManager.GameState.CharacterSelection);
+                if (MasterGameManager.Instance != null)
+                    GameStateMachine.Instance?.TryChangeState(GameStateMachine.GameState.CharacterSelection);
             });
             
             // 던전 버튼
             CreateDebugButton(debugPanel.transform, "Dungeon", new Vector2(0.5f, 0.3f), () => {
-                if (CoreGameManager.Instance != null)
-                    CoreGameManager.Instance.ChangeState(CoreGameManager.GameState.Dungeon);
+                if (MasterGameManager.Instance != null)
+                    GameStateMachine.Instance?.TryChangeState(GameStateMachine.GameState.Dungeon);
             });
             
             Debug.Log("QuickUIBuilder: Debug buttons created");

--- a/MonoChrome/Assets/Scripts/Core/SystemMigrator.cs
+++ b/MonoChrome/Assets/Scripts/Core/SystemMigrator.cs
@@ -104,23 +104,23 @@ namespace MonoChrome.Core
         {
             LogMessage("2단계: Core 매니저들 활성화...");
             
-            // CoreGameManager 찾기 및 활성화
-            CoreGameManager coreGameManager = FindObjectOfType<CoreGameManager>();
+            // MasterGameManager 찾기 및 활성화
+            MasterGameManager coreGameManager = FindObjectOfType<MasterGameManager>();
             if (coreGameManager != null)
             {
                 if (!coreGameManager.gameObject.activeInHierarchy)
                 {
                     coreGameManager.gameObject.SetActive(true);
-                    LogMessage("  ✓ CoreGameManager 활성화됨");
+                    LogMessage("  ✓ MasterGameManager 활성화됨");
                 }
                 else
                 {
-                    LogMessage("  ✓ CoreGameManager 이미 활성화됨");
+                    LogMessage("  ✓ MasterGameManager 이미 활성화됨");
                 }
             }
             else
             {
-                LogMessage("  ⚠ CoreGameManager를 찾을 수 없음 - 3단계에서 생성됩니다");
+                LogMessage("  ⚠ MasterGameManager를 찾을 수 없음 - 3단계에서 생성됩니다");
             }
             
             // CoreUIManager 찾기 및 활성화
@@ -150,12 +150,12 @@ namespace MonoChrome.Core
         {
             LogMessage("3단계: 누락된 Core 컴포넌트 생성...");
             
-            // CoreGameManager 생성
-            if (FindObjectOfType<CoreGameManager>() == null)
+            // MasterGameManager 생성
+            if (FindObjectOfType<MasterGameManager>() == null)
             {
-                GameObject coreGameManagerObj = new GameObject("CoreGameManager");
-                coreGameManagerObj.AddComponent<CoreGameManager>();
-                LogMessage("  ✓ CoreGameManager 생성됨");
+                GameObject coreGameManagerObj = new GameObject("MasterGameManager");
+                coreGameManagerObj.AddComponent<MasterGameManager>();
+                LogMessage("  ✓ MasterGameManager 생성됨");
             }
             
             // CoreUIManager 생성 (Canvas 하위에)
@@ -290,7 +290,7 @@ namespace MonoChrome.Core
             
             // Core 매니저들 확인
             LogMessage("Core 매니저들:");
-            LogMessage($"  CoreGameManager: {(FindObjectOfType<CoreGameManager>() != null ? "있음" : "없음")}");
+            LogMessage($"  MasterGameManager: {(FindObjectOfType<MasterGameManager>() != null ? "있음" : "없음")}");
             LogMessage($"  CoreUIManager: {(FindObjectOfType<CoreUIManager>() != null ? "있음" : "없음")}");
             LogMessage($"  CoreMainMenuController: {(FindObjectOfType<CoreMainMenuController>() != null ? "있음" : "없음")}");
             

--- a/MonoChrome/Assets/Scripts/Setup/ProjectSetupAndValidator.cs
+++ b/MonoChrome/Assets/Scripts/Setup/ProjectSetupAndValidator.cs
@@ -108,12 +108,12 @@ namespace MonoChrome.Setup
         {
             Debug.Log("1. 핵심 컴포넌트 생성 중...");
 
-            // CoreGameManager
-            if (CoreGameManager.Instance == null)
+            // MasterGameManager
+            if (MasterGameManager.Instance == null)
             {
-                GameObject gameManagerGO = new GameObject("[CoreGameManager]");
-                gameManagerGO.AddComponent<CoreGameManager>();
-                Debug.Log("✓ CoreGameManager 생성됨");
+                GameObject gameManagerGO = new GameObject("[MasterGameManager]");
+                gameManagerGO.AddComponent<MasterGameManager>();
+                Debug.Log("✓ MasterGameManager 생성됨");
             }
 
             // GameStateMachine
@@ -185,7 +185,7 @@ namespace MonoChrome.Setup
         {
             Debug.Log("1. 핵심 시스템 존재 검증 중...");
 
-            CheckComponent<CoreGameManager>("CoreGameManager");
+            CheckComponent<MasterGameManager>("MasterGameManager");
             CheckComponent<GameStateMachine>("GameStateMachine");
             CheckComponent<EventBus>("EventBus");
             CheckComponent<DungeonController>("DungeonController");

--- a/MonoChrome/Assets/Scripts/Testing/ImprovedArchitectureTest.cs
+++ b/MonoChrome/Assets/Scripts/Testing/ImprovedArchitectureTest.cs
@@ -127,7 +127,7 @@ namespace MonoChrome.Testing
             Debug.Log("=== 새 게임 플로우 테스트 ===");
             
             // 1. 게임 매니저 통해 새 게임 시작
-            var gameManager = CoreGameManager.Instance;
+            var gameManager = MasterGameManager.Instance;
             if (gameManager != null)
             {
                 gameManager.StartNewGame();
@@ -167,12 +167,12 @@ namespace MonoChrome.Testing
             // 시스템 존재 여부 확인
             var dungeonController = FindObjectOfType<DungeonController>();
             var uiController = FindObjectOfType<UIController>();
-            var gameManager = CoreGameManager.Instance;
+            var gameManager = MasterGameManager.Instance;
             var eventBus = EventBus.Instance;
             
             Debug.Log($"DungeonController: {(dungeonController != null ? "존재" : "없음")}");
             Debug.Log($"UIController: {(uiController != null ? "존재" : "없음")}");
-            Debug.Log($"CoreGameManager: {(gameManager != null ? "존재" : "없음")}");
+            Debug.Log($"MasterGameManager: {(gameManager != null ? "존재" : "없음")}");
             Debug.Log($"EventBus: {(eventBus != null ? "존재" : "없음")}");
             
             if (gameManager != null)

--- a/MonoChrome/Assets/Scripts/Testing/SystemIntegrationChecker.cs
+++ b/MonoChrome/Assets/Scripts/Testing/SystemIntegrationChecker.cs
@@ -75,7 +75,7 @@ namespace MonoChrome.Testing
 
             // 6. 게임 매니저 테스트
             LogInfo("6. 게임 매니저 테스트");
-            TestCoreGameManager();
+            TestMasterGameManager();
             yield return new WaitForSeconds(0.5f);
 
             // 7. 통합 플로우 테스트
@@ -94,13 +94,13 @@ namespace MonoChrome.Testing
             var stateMachine = FindObjectOfType<GameStateMachine>();
             var dungeonController = FindObjectOfType<DungeonController>();
             var uiController = FindObjectOfType<UIController>();
-            var gameManager = FindObjectOfType<CoreGameManager>();
+            var gameManager = FindObjectOfType<MasterGameManager>();
 
             LogInfo($"EventBus: {(eventBus != null ? "✓ 존재" : "✗ 없음")}");
             LogInfo($"GameStateMachine: {(stateMachine != null ? "✓ 존재" : "✗ 없음")}");
             LogInfo($"DungeonController: {(dungeonController != null ? "✓ 존재" : "✗ 없음")}");
             LogInfo($"UIController: {(uiController != null ? "✓ 존재" : "✗ 없음")}");
-            LogInfo($"CoreGameManager: {(gameManager != null ? "✓ 존재" : "✗ 없음")}");
+            LogInfo($"MasterGameManager: {(gameManager != null ? "✓ 존재" : "✗ 없음")}");
 
             // 자동 수정 시도
             if (_enableAutoFix)
@@ -129,12 +129,12 @@ namespace MonoChrome.Testing
                 LogInfo("GameStateMachine 자동 생성됨");
             }
 
-            // CoreGameManager 생성
-            if (CoreGameManager.Instance == null)
+            // MasterGameManager 생성
+            if (MasterGameManager.Instance == null)
             {
-                GameObject gameManagerGO = new GameObject("[CoreGameManager]");
-                gameManagerGO.AddComponent<CoreGameManager>();
-                LogInfo("CoreGameManager 자동 생성됨");
+                GameObject gameManagerGO = new GameObject("[MasterGameManager]");
+                gameManagerGO.AddComponent<MasterGameManager>();
+                LogInfo("MasterGameManager 자동 생성됨");
             }
 
             // DungeonController 생성 (씬에 없을 경우)
@@ -275,11 +275,11 @@ namespace MonoChrome.Testing
             _totalTests++;
         }
 
-        private void TestCoreGameManager()
+        private void TestMasterGameManager()
         {
             LogInfo("개선된 게임 매니저 테스트 중...");
-            
-            var gameManager = CoreGameManager.Instance;
+
+            var gameManager = MasterGameManager.Instance;
             if (gameManager != null)
             {
                 if (gameManager.IsInitialized)
@@ -296,7 +296,7 @@ namespace MonoChrome.Testing
             }
             else
             {
-                LogError("✗ CoreGameManager 인스턴스 없음");
+                LogError("✗ MasterGameManager 인스턴스 없음");
             }
             
             _totalTests++;


### PR DESCRIPTION
## Summary
- mark `CoreGameManager` and `LegacyGameManager` as obsolete
- update menu controller and setup utilities to use `MasterGameManager`
- update debug tools and tests for new manager name
- revise migration helper to activate/create `MasterGameManager`

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_684330c5b5ec8328a0fc6b6ae16bf4f9