### PR TITLE
Unify initialization through single entry

### DIFF
--- a/MonoChrome/Assets/Scripts/Core/ManagerInitializer.cs
+++ b/MonoChrome/Assets/Scripts/Core/ManagerInitializer.cs
@@ -268,8 +268,16 @@ namespace MonoChrome
         {
             if (_debugMode)
                 Debug.Log("ManagerInitializer: Force reinitializing managers");
-                
+
             StartCoroutine(InitializeManagersForScene(SceneManager.GetActiveScene().name));
+        }
+
+        /// <summary>
+        /// Static helper to run initialization using the singleton instance.
+        /// </summary>
+        public static void Initialize()
+        {
+            Instance.ForceReinitializeManagers();
         }
     }
 }

--- a/MonoChrome/Assets/Scripts/Editor/DataInitializer.cs
+++ b/MonoChrome/Assets/Scripts/Editor/DataInitializer.cs
@@ -1,6 +1,7 @@
 using UnityEngine;
 using UnityEditor;
 using System.IO;
+using MonoChrome.Setup;
 
 namespace MonoChrome.Editor
 {
@@ -12,20 +13,26 @@ namespace MonoChrome.Editor
         [MenuItem("MonoChrome/Initialize Game Data")]
         public static void InitializeGameData()
         {
+            // Unified entry point
+            GameInitializer.Initialize(createMasterGameManager: false, initializeGameData: true);
+        }
+
+        public static void GenerateGameData()
+        {
             Debug.Log("Starting game data initialization...");
-            
+
             // 폴더 생성
             CreateDirectories();
-            
+
             // 캐릭터 데이터 생성
             CreateCharacterData();
-            
+
             // 패턴 데이터 생성
             CreatePatternData();
-            
+
             // 데이터 매니저 생성
             CreateDataManagers();
-            
+
             AssetDatabase.Refresh();
             Debug.Log("Game data initialization completed!");
         }

--- a/MonoChrome/Assets/Scripts/Setup/GameInitializer.cs
+++ b/MonoChrome/Assets/Scripts/Setup/GameInitializer.cs
@@ -1,0 +1,50 @@
+using UnityEngine;
+using MonoChrome.Core;
+#if UNITY_EDITOR
+using UnityEditor;
+using MonoChrome.Editor;
+#endif
+
+namespace MonoChrome.Setup
+{
+    /// <summary>
+    /// Unified initialization entry point for project setup.
+    /// Handles data generation, essential manager creation and manager initialization.
+    /// </summary>
+    public static class GameInitializer
+    {
+        /// <summary>
+        /// Run initialization logic.
+        /// </summary>
+        public static void Initialize(bool createMasterGameManager = true, bool initializeGameData = false)
+        {
+#if UNITY_EDITOR
+            if (initializeGameData)
+            {
+                DataInitializer.GenerateGameData();
+            }
+#endif
+            if (createMasterGameManager && MasterGameManager.Instance == null)
+            {
+                var go = new GameObject("[MasterGameManager]");
+                go.AddComponent<MasterGameManager>();
+            }
+
+            ManagerInitializer.Initialize();
+        }
+
+#if UNITY_EDITOR
+        [MenuItem("MonoChrome/Run Full Setup")]
+        public static void RunFullSetup()
+        {
+            Initialize(createMasterGameManager: true, initializeGameData: true);
+        }
+#endif
+
+        [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.BeforeSceneLoad)]
+        private static void RuntimeInitialize()
+        {
+            Initialize(createMasterGameManager: true, initializeGameData: false);
+        }
+    }
+}

--- a/MonoChrome/Assets/Scripts/Setup/SystemStartupInitializer.cs
+++ b/MonoChrome/Assets/Scripts/Setup/SystemStartupInitializer.cs
@@ -1,5 +1,6 @@
 using UnityEngine;
 using MonoChrome.Core;
+using MonoChrome.Setup;
 
 namespace MonoChrome.Setup
 {
@@ -16,71 +17,16 @@ namespace MonoChrome.Setup
 
         private void Awake()
         {
-            // 최우선으로 MasterGameManager 확보
-            EnsureMasterGameManagerExists();
-            
-            // 기타 초기화 수행
-            PerformAdditionalInitialization();
-            
-            // 임무 완료 후 자신을 파괴 (옵션)
+            if (_enableDebugLogs)
+                Debug.Log("[SystemStartupInitializer] Running unified initialization");
+
+            GameInitializer.Initialize(_createMasterGameManager, false);
+
             if (_destroyAfterInitialization)
             {
                 Destroy(gameObject);
             }
         }
 
-        /// <summary>
-        /// MasterGameManager 존재 보장
-        /// </summary>
-        private void EnsureMasterGameManagerExists()
-        {
-            if (!_createMasterGameManager) return;
-
-            if (MasterGameManager.Instance == null)
-            {
-                LogDebug("MasterGameManager가 없어서 생성합니다.");
-                
-                // MasterGameManager를 강제로 생성
-                GameObject go = new GameObject("[MasterGameManager]");
-                go.AddComponent<MasterGameManager>();
-                
-                LogDebug("MasterGameManager 생성 완료");
-            }
-            else
-            {
-                LogDebug("MasterGameManager가 이미 존재합니다.");
-            }
-        }
-
-        /// <summary>
-        /// 추가 초기화 작업
-        /// </summary>
-        private void PerformAdditionalInitialization()
-        {
-            // 필요시 추가 초기화 로직 작성
-            LogDebug("시스템 초기화 완료");
-        }
-
-        /// <summary>
-        /// 수동으로 시스템 초기화 실행 (에디터용)
-        /// </summary>
-        [ContextMenu("Initialize Systems Now")]
-        public void InitializeSystemsManually()
-        {
-            EnsureMasterGameManagerExists();
-            PerformAdditionalInitialization();
-            LogDebug("수동 시스템 초기화 완료");
-        }
-
-        /// <summary>
-        /// 디버그 로그
-        /// </summary>
-        private void LogDebug(string message)
-        {
-            if (_enableDebugLogs)
-            {
-                Debug.Log($"[SystemStartupInitializer] {message}");
-            }
-        }
     }
 }


### PR DESCRIPTION
## Summary
- add `GameInitializer` as a single entry point for project setup
- delegate game data creation through the new initializer
- simplify `SystemStartupInitializer` to call the unified initializer
- expose a static `Initialize` helper in `ManagerInitializer`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684330c8fd108328bd622b6421e1ab2d