### PR TITLE
Enable dungeon room panel transitions

### DIFF
--- a/MonoChrome/Assets/Scripts/Core/Architecture/MasterGameManager.cs
+++ b/MonoChrome/Assets/Scripts/Core/Architecture/MasterGameManager.cs
@@ -458,6 +458,15 @@ namespace MonoChrome.Core
                     // 던전 상태 진입 시 던전 UI 업데이트 요청
                     StartCoroutine(RequestDungeonUIUpdateDelayed());
                     break;
+                case GameStateMachine.GameState.Event:
+                    UIEvents.RequestDungeonSubPanelShow("Event");
+                    break;
+                case GameStateMachine.GameState.Shop:
+                    UIEvents.RequestDungeonSubPanelShow("Shop");
+                    break;
+                case GameStateMachine.GameState.Rest:
+                    UIEvents.RequestDungeonSubPanelShow("Rest");
+                    break;
             }
         }
 

--- a/MonoChrome/Assets/Scripts/Core/Events/GameEvents.cs
+++ b/MonoChrome/Assets/Scripts/Core/Events/GameEvents.cs
@@ -65,9 +65,12 @@ namespace MonoChrome.Events
         
         /// <summary>플레이어 상태 업데이트 요청 이벤트</summary>
         public static event Action<int, int> OnPlayerStatusUpdateRequested;
-        
+
         /// <summary>던전 UI 업데이트 요청 이벤트</summary>
         public static event Action OnDungeonUIUpdateRequested;
+
+        /// <summary>특정 던전 서브 패널 표시 요청 이벤트</summary>
+        public static event Action<string> OnDungeonSubPanelShowRequested;
 
         // 이벤트 발행 메서드들
         public static void RequestPanelShow(string panelName) 
@@ -82,6 +85,9 @@ namespace MonoChrome.Events
         public static void RequestDungeonUIUpdate()
             => OnDungeonUIUpdateRequested?.Invoke();
 
+        public static void RequestDungeonSubPanelShow(string panelName)
+            => OnDungeonSubPanelShowRequested?.Invoke(panelName);
+
         /// <summary>모든 UI 이벤트 구독 해제</summary>
         public static void ClearAllSubscriptions()
         {
@@ -89,6 +95,7 @@ namespace MonoChrome.Events
             OnDungeonMapUpdateRequested = null;
             OnPlayerStatusUpdateRequested = null;
             OnDungeonUIUpdateRequested = null;
+            OnDungeonSubPanelShowRequested = null;
         }
     }
 

--- a/MonoChrome/Assets/Scripts/Systems/UI/DungeonUI.cs
+++ b/MonoChrome/Assets/Scripts/Systems/UI/DungeonUI.cs
@@ -93,6 +93,7 @@ namespace MonoChrome
             UIEvents.OnDungeonMapUpdateRequested += OnDungeonMapUpdateRequested;
             UIEvents.OnPlayerStatusUpdateRequested += OnPlayerStatusUpdateRequested;
             DungeonEvents.OnDungeonGenerated += OnDungeonGenerated;
+            UIEvents.OnDungeonSubPanelShowRequested += OnDungeonSubPanelShowRequested;
         }
         
         /// <summary>
@@ -103,6 +104,7 @@ namespace MonoChrome
             UIEvents.OnDungeonMapUpdateRequested -= OnDungeonMapUpdateRequested;
             UIEvents.OnPlayerStatusUpdateRequested -= OnPlayerStatusUpdateRequested;
             DungeonEvents.OnDungeonGenerated -= OnDungeonGenerated;
+            UIEvents.OnDungeonSubPanelShowRequested -= OnDungeonSubPanelShowRequested;
         }
         
         /// <summary>
@@ -119,6 +121,25 @@ namespace MonoChrome
         private void OnPlayerStatusUpdateRequested(int currentHealth, int maxHealth)
         {
             UpdatePlayerStatus(currentHealth, maxHealth);
+        }
+
+        /// <summary>
+        /// 서브 패널 표시 요청 이벤트 핸들러
+        /// </summary>
+        private void OnDungeonSubPanelShowRequested(string panelName)
+        {
+            switch (panelName)
+            {
+                case "Event":
+                    ShowEventPanel();
+                    break;
+                case "Shop":
+                    ShowShopPanel();
+                    break;
+                case "Rest":
+                    ShowRestPanel();
+                    break;
+            }
         }
         
         /// <summary>


### PR DESCRIPTION
## Summary
- trigger event to show specific dungeon sub-panels
- handle new event in `DungeonUI`
- request appropriate panel when entering Event, Shop, or Rest states

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_68486600d1448328a56230bd9789a924